### PR TITLE
Fix template lookup path

### DIFF
--- a/src/ADOGenerator/Services/TemplateService.cs
+++ b/src/ADOGenerator/Services/TemplateService.cs
@@ -106,7 +106,7 @@ public class TemplateService : ITemplateService
 
     public IEnumerable<TemplateSelection.Template> GetAvailableTemplates()
     {
-        var templatesPath = Path.Combine(Directory.GetCurrentDirectory(), "Templates", "TemplateSetting.json");
+        var templatesPath = Path.Combine(AppContext.BaseDirectory, "Templates", "TemplateSetting.json");
         if (!File.Exists(templatesPath))
         {
             return Enumerable.Empty<TemplateSelection.Template>();


### PR DESCRIPTION
## Summary
- resolve template directory using `AppContext.BaseDirectory`

## Testing
- `dotnet build src/ADOGenerator.sln`
- `dotnet run --no-build --project src/ADOGenerator.Web --urls http://localhost:5000`
- `curl -s http://localhost:5000/api/templates | head -c 200`

------
https://chatgpt.com/codex/tasks/task_e_687955ddb3688331882d032a33ca8e8e